### PR TITLE
Additional compatibility for GEP_CommNet

### DIFF
--- a/OptionalMods/GEP_CommNet/GameData/GEP/GEP_CommNet/Antenna.cfg
+++ b/OptionalMods/GEP_CommNet/GameData/GEP/GEP_CommNet/Antenna.cfg
@@ -10,7 +10,7 @@
 	@description = The Communotron 7-1000 directional antenna borrows the folding design of the smaller 88-88 model. With a rating ten times greater than previous models, this enormous antenna can maintain communications with a Level 3 Tracking Station from the edge of the solar system. And when combined with the powerful Level 4 Tracking Station, communications can reach the neighboring star system.
 	@bulkheadProfiles = size1, srf
 	!mesh = nope
-	MODEL
+	MODEL:NEEDS[!ReStock]
 	{
 		model = Squad/Parts/Utility/commDish88-88/model
 		texture = comm_dish_array, GEP/GEP_CommNet/comm_dish_array

--- a/OptionalMods/GEP_CommNet/GameData/GEP/GEP_CommNet/Antenna.cfg
+++ b/OptionalMods/GEP_CommNet/GameData/GEP/GEP_CommNet/Antenna.cfg
@@ -1,4 +1,4 @@
-+PART[commDish]:NEEDS[GEP,!JX2Antenna]
++PART[commDish]:NEEDS[GEP,!JX2Antenna,!NearFutureExploration]
 {
 	@name = commDishXL
 	@rescaleFactor = 3

--- a/OptionalMods/GEP_CommNet/GameData/GEP/GEP_CommNet/Antenna.cfg
+++ b/OptionalMods/GEP_CommNet/GameData/GEP/GEP_CommNet/Antenna.cfg
@@ -18,6 +18,15 @@
 		texture = model000, GEP/GEP_CommNet/model000
 		scale = 1, 1, 1
 	}
+	%MODEL:NEEDS[ReStock]
+	{
+		%model = ReStock/Assets/Communication/restock-antenna-stack-4
+	}
+	@MODULE[ModuleDeployableAntenna]:NEEDS[ReStock]
+	{
+		@animationName = Deploy
+		@pivotName = Dish
+	}
 	@MODULE[ModuleDataTransmitter]
 	{
 		@antennaPower = 1000000000000

--- a/OptionalMods/GEP_CommNet/GameData/GEP/GEP_CommNet/GEP_CommNet.restockblacklist
+++ b/OptionalMods/GEP_CommNet/GameData/GEP/GEP_CommNet/GEP_CommNet.restockblacklist
@@ -1,0 +1,1 @@
+GEP/GEP_CommNet


### PR DESCRIPTION
- Added Restock compatibility. If Restock was installed, the new antenna would not appear because it used blacklisted stock assets. This change makes the new antenna use Restock assets instead of stock/custom assets, if Restock is installed. 
- The new antenna no longer appears if Near Future Exploration is installed. Like JX2, NFX adds its own antenna with range measured in T.