### PR TITLE
Fix CommNet Restock Blacklist

### DIFF
--- a/OptionalMods/GEP_CommNet/GameData/GEP/GEP_CommNet/GEP_CommNet.restockblacklist
+++ b/OptionalMods/GEP_CommNet/GameData/GEP/GEP_CommNet/GEP_CommNet.restockblacklist
@@ -1,1 +1,1 @@
-GEP/GEP_CommNet
+GEP/GEP_CommNet/


### PR DESCRIPTION
Added a trailing slash that I had accidentally left out. The blacklist file now works correctly. This fixes a non-critical bug - the only effect is that Restock users save ~2MB of RAM.