### PR TITLE
Fix version file syntax errors

### DIFF
--- a/GameData/GEP/Version/GrannusExpansionPack.version
+++ b/GameData/GEP/Version/GrannusExpansionPack.version
@@ -17,10 +17,10 @@
     "MAJOR": 1,
     "MINOR": 12,
     "PATCH": 1
-  }
+  },
   "KSP_VERSION_MAX":{
     "MAJOR": 1,
     "MINOR": 12,
     "PATCH": 99
-  },
+  }
 }


### PR DESCRIPTION
Hi @OhioBob, this mod's version file has just acquired some new syntax errors in 6efbd2d5902c65bb1bfc08df1a979388230485b5 which have blocked it from being indexed in CKAN (along with the Primary, CommNet, and Rescale modules). Fixes are attached to this pull request.

I would recommend setting up @DasSkelett's validation utility https://github.com/DasSkelett/AVC-VersionFileValidator to catch things like this before release in the future.